### PR TITLE
Standardize currency to BRL in integration test repositories

### DIFF
--- a/CURRENCY_CLEANUP_SUMMARY.md
+++ b/CURRENCY_CLEANUP_SUMMARY.md
@@ -1,0 +1,57 @@
+# Currency Cleanup Summary
+
+## Objective
+Remove all integration tests that cover different currencies, standardizing on BRL (Brazilian Real) only for integration testing, while preserving multi-currency testing in unit tests for proper domain validation.
+
+## Files Updated
+
+### Integration Tests (Updated to use only BRL)
+All integration test files in `server/tests/integration/database/` were updated to use BRL currency:
+
+1. **postgresql-bucket-transfer.repository.test.ts**
+   - Changed all Money instantiations from USD to BRL
+   - All test scenarios now use Brazilian Real
+
+2. **postgresql-savings-bucket.repository.test.ts** 
+   - Updated multiple currency references (USD, EUR, GBP) to BRL
+   - All Money objects in test data now use BRL consistently
+
+3. **postgresql-transaction.repository.test.ts**
+   - Converted all USD references to BRL
+   - Transaction test data now uses Brazilian Real
+
+4. **postgresql-installment-plan.repository.test.ts**
+   - Updated default totalAmount from USD to BRL
+   - Installment plan tests now use Brazilian Real
+
+5. **postgresql-subscription.repository.test.ts**
+   - Fixed remaining USD references in:
+     - `createTestSubscription` function default monthlyAmount
+     - Netflix subscription test case
+   - All subscription tests now use BRL consistently
+
+### Unit Tests (Preserved multi-currency testing)
+Unit tests were intentionally left unchanged as they properly test:
+- **Money value object functionality** with different currencies (USD, EUR)
+- **Cross-currency validation** ensuring operations fail when mixing currencies
+- **Domain business rules** that prevent currency mismatches
+
+## Results
+- ✅ All integration tests now use only BRL currency
+- ✅ Database integration testing standardized on Brazilian Real  
+- ✅ Unit tests preserve proper multi-currency validation testing
+- ✅ No remaining USD, EUR, or GBP references in integration tests
+- ✅ Ready for .env configuration without local database dependencies
+
+## Files Affected
+- `server/tests/integration/database/postgresql-bucket-transfer.repository.test.ts`
+- `server/tests/integration/database/postgresql-savings-bucket.repository.test.ts`
+- `server/tests/integration/database/postgresql-transaction.repository.test.ts`
+- `server/tests/integration/database/postgresql-installment-plan.repository.test.ts`
+- `server/tests/integration/database/postgresql-subscription.repository.test.ts`
+
+## Validation
+Final verification confirmed:
+- No USD/EUR/GBP currency references remain in integration tests
+- All Money object instantiations in integration tests use 'BRL'
+- Unit tests appropriately maintain multi-currency testing for domain validation

--- a/server/tests/integration/database/postgresql-bucket-transfer.repository.test.ts
+++ b/server/tests/integration/database/postgresql-bucket-transfer.repository.test.ts
@@ -35,8 +35,8 @@ describe('PostgreSQLBucketTransferRepository Integration Tests', () => {
     testSavingsBucket = new SavingsBucket(
       randomUUID(),
       'Test Bucket for Transfers',
-      new Money(1000, 'USD'), // target
-      new Money(500, 'USD')  // balance
+      new Money(1000, 'BRL'), // target
+      new Money(500, 'BRL')  // balance
     );
     await testSql`
       INSERT INTO savings_buckets (id, name, target_amount, current_balance, description, is_active, created_at, updated_at)
@@ -65,7 +65,7 @@ describe('PostgreSQLBucketTransferRepository Integration Tests', () => {
     return new BucketTransfer(
       id,
       props.date || now,
-      props.amount || new Money(100, 'USD'),
+      props.amount || new Money(100, 'BRL'),
       props.type || BucketTransferType.DEPOSIT,
       props.bucketId || testSavingsBucket.id,
       props.description === undefined ? 'Test Transfer' : props.description,
@@ -79,7 +79,7 @@ describe('PostgreSQLBucketTransferRepository Integration Tests', () => {
       const transfer = createTestBucketTransfer({
         description: 'Initial Deposit',
         type: BucketTransferType.DEPOSIT,
-        amount: new Money(200, 'USD')
+        amount: new Money(200, 'BRL')
       });
       await repository.save(transfer);
 
@@ -136,13 +136,13 @@ describe('PostgreSQLBucketTransferRepository Integration Tests', () => {
       const originalDate = new Date('2024-01-01T12:00:00Z');
       const transfer = createTestBucketTransfer({
         description: 'Original Desc',
-        amount: new Money(100, 'USD'),
+        amount: new Money(100, 'BRL'),
         date: originalDate
       });
       await repository.save(transfer);
 
       const newDescription = 'Updated Desc';
-      const newAmount = new Money(150, 'USD');
+      const newAmount = new Money(150, 'BRL');
       const newDate = new Date('2024-01-02T12:00:00Z');
 
       // Create a new entity instance for update, as per repository pattern
@@ -179,7 +179,7 @@ describe('PostgreSQLBucketTransferRepository Integration Tests', () => {
 
   describe('findByBucket', () => {
     it('should return all transfers for a specific bucketId', async () => {
-      const bucket2 = new SavingsBucket(randomUUID(), 'Bucket 2', null, new Money(0));
+      const bucket2 = new SavingsBucket(randomUUID(), 'Bucket 2', null, new Money(0, 'BRL'));
       await testSql`INSERT INTO savings_buckets (id, name, current_balance, created_at, updated_at) VALUES (${bucket2.id}, ${bucket2.name}, ${bucket2.currentBalance.amount}, ${bucket2.createdAt.toISOString()}, ${bucket2.updatedAt.toISOString()})`;
 
       const transfer1 = createTestBucketTransfer({ bucketId: testSavingsBucket.id });

--- a/server/tests/integration/database/postgresql-installment-plan.repository.test.ts
+++ b/server/tests/integration/database/postgresql-installment-plan.repository.test.ts
@@ -61,7 +61,7 @@ describe('PostgreSQLInstallmentPlanRepository Integration Tests', () => {
     const now = new Date();
     return new InstallmentPlan(
       id,
-      props.totalAmount || new Money(1200, 'USD'),
+      props.totalAmount || new Money(1200, 'BRL'),
       props.purchaseDate || new Date(now.getFullYear(), now.getMonth(), 15),
       props.installmentCount || 12,
       props.description || `Test Plan ${id.substring(0, 8)}`,

--- a/server/tests/integration/database/postgresql-savings-bucket.repository.test.ts
+++ b/server/tests/integration/database/postgresql-savings-bucket.repository.test.ts
@@ -43,8 +43,8 @@ describe('PostgreSQLSavingsBucketRepository Integration Tests', () => {
   } = {}): SavingsBucket => {
     const id = props.id || randomUUID();
     const name = props.name || `Test Bucket ${id.substring(0, 8)}`;
-    const targetAmount = props.targetAmount === undefined ? new Money(1000, 'USD') : props.targetAmount;
-    const currentBalance = props.currentBalance || new Money(0, 'USD');
+    const targetAmount = props.targetAmount === undefined ? new Money(1000, 'BRL') : props.targetAmount;
+    const currentBalance = props.currentBalance || new Money(0, 'BRL');
     const description = props.description === undefined ? 'Test description' : props.description;
     const isActive = props.isActive !== undefined ? props.isActive : true;
     const createdAt = props.createdAt || new Date();
@@ -67,8 +67,8 @@ describe('PostgreSQLSavingsBucketRepository Integration Tests', () => {
     it('should save a new savings bucket and retrieve it by ID', async () => {
       const bucket = createTestSavingsBucket({
         name: 'Vacation Fund',
-        targetAmount: new Money(2000, 'EUR'),
-        currentBalance: new Money(500, 'EUR'),
+        targetAmount: new Money(2000, 'BRL'),
+        currentBalance: new Money(500, 'BRL'),
         description: 'For a trip to Europe'
       });
       await repository.save(bucket);
@@ -94,7 +94,7 @@ describe('PostgreSQLSavingsBucketRepository Integration Tests', () => {
       const bucket = createTestSavingsBucket({
         targetAmount: null,
         description: null,
-        currentBalance: new Money(100, 'GBP')
+        currentBalance: new Money(100, 'BRL')
       });
       await repository.save(bucket);
       const found = await repository.findById(bucket.id);
@@ -129,7 +129,7 @@ describe('PostgreSQLSavingsBucketRepository Integration Tests', () => {
 
   describe('update', () => {
     it('should update an existing savings bucket', async () => {
-      const bucket = createTestSavingsBucket({ name: 'Initial Name', currentBalance: new Money(100, 'USD') });
+      const bucket = createTestSavingsBucket({ name: 'Initial Name', currentBalance: new Money(100, 'BRL') });
       await repository.save(bucket);
       const initialUpdatedAt = (await repository.findById(bucket.id))!.updatedAt;
 
@@ -137,8 +137,8 @@ describe('PostgreSQLSavingsBucketRepository Integration Tests', () => {
 
       bucket.updateName('Updated Name');
       bucket.updateDescription('Updated Description');
-      bucket.updateTargetAmount(new Money(5000, 'USD'));
-      bucket.addFunds(new Money(200, 'USD')); // currentBalance is now 300
+      bucket.updateTargetAmount(new Money(5000, 'BRL'));
+      bucket.addFunds(new Money(200, 'BRL')); // currentBalance is now 300
       bucket.deactivate();
 
       await repository.update(bucket);
@@ -210,9 +210,9 @@ describe('PostgreSQLSavingsBucketRepository Integration Tests', () => {
 
   describe('findBucketsWithTargets', () => {
     it('should return active buckets that have a target amount', async () => {
-      const withTarget = createTestSavingsBucket({ name: 'Targeted', targetAmount: new Money(100) });
+      const withTarget = createTestSavingsBucket({ name: 'Targeted', targetAmount: new Money(100, 'BRL') });
       const noTarget = createTestSavingsBucket({ name: 'Untargeted', targetAmount: null });
-      const inactiveWithTarget = createTestSavingsBucket({ name: 'Inactive Targeted', targetAmount: new Money(100), isActive: false });
+      const inactiveWithTarget = createTestSavingsBucket({ name: 'Inactive Targeted', targetAmount: new Money(100, 'BRL'), isActive: false });
 
       await repository.save(withTarget);
       await repository.save(noTarget);
@@ -226,7 +226,7 @@ describe('PostgreSQLSavingsBucketRepository Integration Tests', () => {
 
   describe('findBucketsWithoutTargets', () => {
     it('should return active buckets that do not have a target amount', async () => {
-      const withTarget = createTestSavingsBucket({ name: 'Targeted One', targetAmount: new Money(100) });
+      const withTarget = createTestSavingsBucket({ name: 'Targeted One', targetAmount: new Money(100, 'BRL') });
       const noTarget = createTestSavingsBucket({ name: 'Untargeted One', targetAmount: null });
       const inactiveNoTarget = createTestSavingsBucket({ name: 'Inactive Untargeted', targetAmount: null, isActive: false });
 
@@ -242,10 +242,10 @@ describe('PostgreSQLSavingsBucketRepository Integration Tests', () => {
 
   describe('findTargetReachedBuckets', () => {
     it('should return active buckets where current balance is greater than or equal to target amount', async () => {
-      const targetReached = createTestSavingsBucket({ name: 'Reached', targetAmount: new Money(500), currentBalance: new Money(550) });
-      const targetNotReached = createTestSavingsBucket({ name: 'Not Reached', targetAmount: new Money(500), currentBalance: new Money(450) });
-      const targetReachedInactive = createTestSavingsBucket({ name: 'Reached Inactive', targetAmount: new Money(500), currentBalance: new Money(500), isActive: false });
-      const noTargetBucket = createTestSavingsBucket({ name: 'No Target Reached', targetAmount: null, currentBalance: new Money(1000) });
+      const targetReached = createTestSavingsBucket({ name: 'Reached', targetAmount: new Money(500, 'BRL'), currentBalance: new Money(550, 'BRL') });
+      const targetNotReached = createTestSavingsBucket({ name: 'Not Reached', targetAmount: new Money(500, 'BRL'), currentBalance: new Money(450, 'BRL') });
+      const targetReachedInactive = createTestSavingsBucket({ name: 'Reached Inactive', targetAmount: new Money(500, 'BRL'), currentBalance: new Money(500, 'BRL'), isActive: false });
+      const noTargetBucket = createTestSavingsBucket({ name: 'No Target Reached', targetAmount: null, currentBalance: new Money(1000, 'BRL') });
 
       await repository.save(targetReached);
       await repository.save(targetNotReached);

--- a/server/tests/integration/database/postgresql-subscription.repository.test.ts
+++ b/server/tests/integration/database/postgresql-subscription.repository.test.ts
@@ -63,7 +63,7 @@ describe('PostgreSQLSubscriptionRepository Integration Tests', () => {
     return new Subscription(
       id,
       props.name || `Test Sub ${id.substring(0, 8)}`,
-      props.monthlyAmount || new Money(10, 'USD'),
+      props.monthlyAmount || new Money(10, 'BRL'),
       props.startDate || new Date(now.getFullYear(), now.getMonth(), 1),
       props.categoryId || testCategory.id,
       props.paymentMethodId || testPaymentMethod.id,
@@ -76,7 +76,7 @@ describe('PostgreSQLSubscriptionRepository Integration Tests', () => {
 
   describe('save and findById', () => {
     it('should save a new subscription and retrieve it by ID', async () => {
-      const sub = createTestSubscription({ name: 'Netflix', monthlyAmount: new Money(15.99, 'USD') });
+      const sub = createTestSubscription({ name: 'Netflix', monthlyAmount: new Money(15.99, 'BRL') });
       await repository.save(sub);
 
       const found = await repository.findById(sub.id);

--- a/server/tests/integration/database/postgresql-transaction.repository.test.ts
+++ b/server/tests/integration/database/postgresql-transaction.repository.test.ts
@@ -80,7 +80,7 @@ describe('PostgreSQLTransactionRepository Integration Tests', () => {
       const transaction = new Transaction(
         transactionId,
         transactionDate,
-        new Money(100.50, 'USD'),
+        new Money(100.50, 'BRL'),
         testCategory.id,
         testPaymentMethod.id,
         new TransactionTypeVO(TransactionType.EXPENSE),
@@ -131,7 +131,7 @@ describe('PostgreSQLTransactionRepository Integration Tests', () => {
       let transaction = new Transaction(
         transactionId,
         initialDate,
-        new Money(150.00, 'USD'),
+        new Money(150.00, 'BRL'),
         testCategory.id,
         testPaymentMethod.id,
         new TransactionTypeVO(TransactionType.EXPENSE),
@@ -148,7 +148,7 @@ describe('PostgreSQLTransactionRepository Integration Tests', () => {
       await new Promise(resolve => setTimeout(resolve, 10));
 
       const newDescription = 'Updated transaction description';
-      const newAmount = new Money(200.75, 'USD');
+      const newAmount = new Money(200.75, 'BRL');
 
       // Re-fetch or re-create the domain object to update
       // For this test, we create a new instance with the same ID and updated values
@@ -179,7 +179,7 @@ describe('PostgreSQLTransactionRepository Integration Tests', () => {
       const transaction = new Transaction(
         randomUUID(),
         new Date(),
-        new Money(50.00, 'USD'),
+        new Money(50.00, 'BRL'),
         testCategory.id,
         testPaymentMethod.id,
         new TransactionTypeVO(TransactionType.EXPENSE),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a summary document outlining the standardization of integration tests to exclusively use the Brazilian Real (BRL) currency.

- **Tests**
  - Updated all integration tests to replace USD, EUR, and GBP currency references with BRL across bucket transfers, savings buckets, transactions, installment plans, and subscriptions.
  - Ensured unit tests continue to validate multi-currency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->